### PR TITLE
refactor!: Change API to use argument structs as entrypoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "color-eyre",
  "dirs-next",

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@
 // Software.
 
 use eyre::Result;
-use sn_launch_tool::run;
-pub use sn_launch_tool::run_with;
+use sn_launch_tool::Launch;
+use structopt::StructOpt;
 use tracing::debug;
 
 fn main() -> Result<()> {
@@ -18,5 +18,5 @@ fn main() -> Result<()> {
 
     debug!("Launching Safe nodes...");
 
-    run()
+    Launch::from_args().run()
 }


### PR DESCRIPTION
- fa49b85 **refactor!: Change API to use argument structs as entrypoints**

  Rather than the API being 'stringly typed' (e.g. passing arguments as
  `&[&str]`) we now make the argument struct public (under new names,
  `Launch` and `Join`). This makes the API more idiomatic to use.
  
  Currently, `structopt` is required to construct the argument structs,
  but this could be relaxed in future.
  
  BREAKING CHANGE: The `run`, `run_with`, `join`, and `join_with`
  functions have been removed. Instead use `Launch::run` or `Join::run`.
  These structs can be constructed via the `StructOpt` constructors.
