### PR TITLE
Excessive refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "sn_launch_tool"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "color-eyre",
  "dirs-next",

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,0 +1,196 @@
+use eyre::{eyre, Result, WrapErr};
+use std::{
+    borrow::Cow,
+    ffi::{OsStr, OsString},
+    fmt,
+    net::SocketAddr,
+    path::Path,
+    process::{Command, Stdio},
+    thread,
+    time::Duration,
+};
+use tracing::{debug, trace};
+
+const NODE_LIVENESS_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Clone)]
+pub(crate) struct NodeCmd<'a> {
+    path: Cow<'a, OsStr>,
+    envs: Vec<(Cow<'a, OsStr>, Cow<'a, OsStr>)>,
+    args: NodeArgs<'a>,
+}
+
+impl<'a> NodeCmd<'a> {
+    pub(crate) fn new<P, Pb>(path: P) -> Self
+    where
+        P: Into<Cow<'a, Pb>>,
+        Pb: AsRef<OsStr> + ToOwned + ?Sized + 'a,
+        Pb::Owned: Into<OsString>,
+    {
+        Self {
+            path: into_cow_os_str(path),
+            envs: Default::default(),
+            args: Default::default(),
+        }
+    }
+
+    fn path(&self) -> &Path {
+        Path::new(&self.path)
+    }
+
+    pub(crate) fn args(&self) -> &NodeArgs {
+        &self.args
+    }
+
+    pub(crate) fn push_env<K, Kb, V, Vb>(&mut self, key: K, value: V)
+    where
+        K: Into<Cow<'a, Kb>>,
+        Kb: AsRef<OsStr> + ToOwned + ?Sized + 'a,
+        Kb::Owned: Into<OsString>,
+        V: Into<Cow<'a, Vb>>,
+        Vb: AsRef<OsStr> + ToOwned + ?Sized + 'a,
+        Vb::Owned: Into<OsString>,
+    {
+        self.envs
+            .push((into_cow_os_str(key), into_cow_os_str(value)));
+    }
+
+    pub(crate) fn push_arg<A, B>(&mut self, arg: A)
+    where
+        A: Into<Cow<'a, B>>,
+        B: AsRef<OsStr> + ToOwned + ?Sized + 'a,
+        B::Owned: Into<OsString>,
+    {
+        self.args.push(arg);
+    }
+
+    pub(crate) fn print_version(&self) -> Result<()> {
+        let version = Command::new(&self.path)
+            .args(&["-V"])
+            .output()
+            .map_or_else(
+                |error| Err(eyre!(error)),
+                |output| {
+                    if output.status.success() {
+                        Ok(output.stdout)
+                    } else {
+                        Err(eyre!(
+                            "Process exited with non-zero status (status: {}, stderr: {})",
+                            output.status,
+                            String::from_utf8_lossy(&output.stderr)
+                        ))
+                    }
+                },
+            )
+            .wrap_err_with(|| {
+                format!(
+                    "Failed to run '{}' with args '{:?}'",
+                    self.path().display(),
+                    &["-V"]
+                )
+            })?;
+
+        debug!(
+            "Using sn_node @ {} from {}",
+            String::from_utf8_lossy(&version).trim(),
+            self.path().display()
+        );
+
+        Ok(())
+    }
+
+    pub(crate) fn run(&self, node_dir: impl AsRef<Path>, contacts: &[SocketAddr]) -> Result<()> {
+        let path_str = self.path().display().to_string();
+        trace!("Running '{}' with args {:?} ...", path_str, self.args);
+
+        let mut extra_args = NodeArgs::default();
+        extra_args.push("--root-dir");
+        extra_args.push(node_dir.as_ref());
+        extra_args.push("--log-dir");
+        extra_args.push(node_dir.as_ref());
+
+        if !contacts.is_empty() {
+            extra_args.push("--hard-coded-contacts");
+            extra_args.push(
+                serde_json::to_string(
+                    &contacts
+                        .iter()
+                        .map(|contact| contact.to_string())
+                        .collect::<Vec<_>>(),
+                )
+                .wrap_err("Failed to generate genesis contacts list parameter")?,
+            );
+        }
+
+        Command::new(&path_str)
+            .args(&self.args)
+            .args(&extra_args)
+            .envs(self.envs.iter().map(
+                // this looks like a no-op but really converts `&(_, _)` into `(_, _)`
+                |(key, value)| (key, value),
+            ))
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|error| eyre!(error))
+            .and_then(|mut child| {
+                // Wait a couple of seconds to see if the node fails immediately, so we can fail fast
+                thread::sleep(NODE_LIVENESS_TIMEOUT);
+
+                if let Some(status) = child.try_wait()? {
+                    return Err(eyre!("Node exited early (status: {})", status));
+                }
+
+                Ok(())
+            })
+            .wrap_err_with(|| {
+                format!("Failed to start '{}' with args '{:?}'", path_str, self.args)
+            })?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct NodeArgs<'a>(Vec<Cow<'a, OsStr>>);
+
+impl<'a> NodeArgs<'a> {
+    fn push<A, B>(&mut self, arg: A)
+    where
+        A: Into<Cow<'a, B>>,
+        B: AsRef<OsStr> + ToOwned + ?Sized + 'a,
+        B::Owned: Into<OsString>,
+    {
+        self.0.push(into_cow_os_str(arg));
+    }
+}
+
+impl<'a> IntoIterator for &'a NodeArgs<'a> {
+    type Item = &'a Cow<'a, OsStr>;
+
+    type IntoIter = std::slice::Iter<'a, Cow<'a, OsStr>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a> fmt::Debug for NodeArgs<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list()
+            .entries(self.0.iter().map(|arg| -> &OsStr { arg.as_ref() }))
+            .finish()
+    }
+}
+
+fn into_cow_os_str<'a, V, Vb>(val: V) -> Cow<'a, OsStr>
+where
+    V: Into<Cow<'a, Vb>>,
+    Vb: AsRef<OsStr> + ToOwned + ?Sized + 'a,
+    Vb::Owned: Into<OsString>,
+{
+    match val.into() {
+        Cow::Borrowed(val) => val.as_ref().into(),
+        Cow::Owned(val) => val.into().into(),
+    }
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -9,7 +9,7 @@ use std::{
     thread,
     time::Duration,
 };
-use tracing::{debug, trace};
+use tracing::trace;
 
 const NODE_LIVENESS_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -34,7 +34,7 @@ impl<'a> NodeCmd<'a> {
         }
     }
 
-    fn path(&self) -> &Path {
+    pub(crate) fn path(&self) -> &Path {
         Path::new(&self.path)
     }
 
@@ -64,7 +64,7 @@ impl<'a> NodeCmd<'a> {
         self.args.push(arg);
     }
 
-    pub(crate) fn print_version(&self) -> Result<()> {
+    pub(crate) fn version(&self) -> Result<String> {
         let version = Command::new(&self.path)
             .args(&["-V"])
             .output()
@@ -90,13 +90,7 @@ impl<'a> NodeCmd<'a> {
                 )
             })?;
 
-        debug!(
-            "Using sn_node @ {} from {}",
-            String::from_utf8_lossy(&version).trim(),
-            self.path().display()
-        );
-
-        Ok(())
+        Ok(String::from_utf8_lossy(&version).trim().to_string())
     }
 
     pub(crate) fn run(&self, node_dir: impl AsRef<Path>, contacts: &[SocketAddr]) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,10 @@ impl Launch {
         node_cmd.push_arg("--keep-alive-interval-msec");
         node_cmd.push_arg(self.keep_alive_interval_msec.to_string());
 
+        if self.is_local {
+            node_cmd.push_arg("--skip-igd");
+        }
+
         debug!("Network size: {} nodes", self.num_nodes);
 
         let interval = Duration::from_secs(self.interval);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,11 +223,9 @@ fn launch(args: &Launch) -> Result<()> {
 
     debug!("Network size: {} nodes", args.num_nodes);
 
-    let adding_nodes: bool = args.add_nodes_to_existing_network;
-
     let interval_duration = Duration::from_secs(args.interval);
 
-    if !adding_nodes {
+    if !args.add_nodes_to_existing_network {
         // Set genesis node's command arguments
         let mut genesis_cmd = node_cmd.clone();
         genesis_cmd.push_arg("--first");
@@ -266,7 +264,7 @@ fn launch(args: &Launch) -> Result<()> {
         return Err(eyre!("A genesis node could not be found."));
     }
 
-    let end: usize = if adding_nodes {
+    let end: usize = if args.add_nodes_to_existing_network {
         existing_nodes_count + args.num_nodes
     } else {
         args.num_nodes
@@ -276,7 +274,7 @@ fn launch(args: &Launch) -> Result<()> {
     for i in existing_nodes_count..end {
         let this_node = i + 1;
 
-        if adding_nodes {
+        if args.add_nodes_to_existing_network {
             debug!("Adding node #{}...", this_node)
         } else {
             debug!("Launching node #{}...", this_node)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,10 @@ impl CommonArgs {
     fn node_cmd(&self) -> Result<NodeCmd> {
         let mut cmd = NodeCmd::new(self.node_path()?);
 
-        cmd.push_env("RUST_LOG", self.rust_log());
+        let rust_log = self.rust_log();
+        info!("Using RUST_LOG '{}'", rust_log);
+
+        cmd.push_env("RUST_LOG", rust_log);
         cmd.push_arg(
             // We need a minimum of INFO level for nodes verbosity,
             // since the genesis node logs the contact info at INFO level
@@ -222,9 +225,6 @@ fn launch(args: &Launch) -> Result<()> {
 
     let adding_nodes: bool = args.add_nodes_to_existing_network;
 
-    let rust_log = args.common.rust_log();
-    info!("Using RUST_LOG '{}'", rust_log);
-    // Get port number of genesis node to pass it as hard-coded contact to the other nodes
     let interval_duration = Duration::from_secs(args.interval);
 
     if !adding_nodes {
@@ -302,9 +302,6 @@ fn join(args: &Join) -> Result<()> {
         debug!("Failed to start a node. No contacts nodes provided.");
         return Ok(());
     }
-
-    let rust_log = args.common.rust_log();
-    info!("Using RUST_LOG '{}'", rust_log);
 
     debug!("Node to be started with contact(s): {:?}", args.hard_coded_contacts);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
     fs::File,
     io::{self, BufReader},
     net::SocketAddr,
-    path::{Path, PathBuf},
+    path::PathBuf,
     thread,
     time::Duration,
 };
@@ -82,18 +82,83 @@ pub struct Launch {
 impl Launch {
     /// Launch a network with these arguments.
     pub fn run(&self) -> Result<()> {
-        launch(self)
-    }
+        let mut node_cmd = self.common.node_cmd()?;
+        node_cmd.print_version()?;
 
-    fn node_cmd(&self) -> Result<NodeCmd<'_>> {
-        let mut cmd = self.common.node_cmd()?;
+        node_cmd.push_arg("--idle-timeout-msec");
+        node_cmd.push_arg(self.idle_timeout_msec.to_string());
+        node_cmd.push_arg("--keep-alive-interval-msec");
+        node_cmd.push_arg(self.keep_alive_interval_msec.to_string());
 
-        cmd.push_arg("--idle-timeout-msec");
-        cmd.push_arg(self.idle_timeout_msec.to_string());
-        cmd.push_arg("--keep-alive-interval-msec");
-        cmd.push_arg(self.keep_alive_interval_msec.to_string());
+        debug!("Network size: {} nodes", self.num_nodes);
 
-        Ok(cmd)
+        let interval_duration = Duration::from_secs(self.interval);
+
+        if !self.add_nodes_to_existing_network {
+            // Set genesis node's command arguments
+            let mut genesis_cmd = node_cmd.clone();
+            genesis_cmd.push_arg("--first");
+            if let Some(ip) = &self.ip {
+                genesis_cmd.push_arg(format!("{}:0", ip));
+            } else {
+                genesis_cmd.push_arg("127.0.0.1:0");
+            }
+
+            // Let's launch genesis node now
+            debug!("Launching genesis node (#1)...");
+            genesis_cmd.run(self.nodes_dir.join("sn-node-genesis"), &[])?;
+
+            thread::sleep(interval_duration);
+        }
+
+        // Fetch node_conn_info from $HOME/.safe/node/node_connection_info.config.
+        let genesis_contact_info = read_genesis_conn_info()?;
+
+        debug!(
+            "Common node args for launching the network: {:?}",
+            node_cmd.args()
+        );
+
+        let paths =
+            fs::read_dir(&self.nodes_dir).wrap_err("Could not read existing testnet log dir")?;
+
+        let existing_nodes_count = paths
+            .collect::<Result<Vec<_>, io::Error>>()
+            .wrap_err("Error collecting testnet log dir")?
+            .len();
+
+        info!("{:?} existing nodes found", existing_nodes_count);
+
+        if existing_nodes_count == 0 {
+            return Err(eyre!("A genesis node could not be found."));
+        }
+
+        let end: usize = if self.add_nodes_to_existing_network {
+            existing_nodes_count + self.num_nodes
+        } else {
+            self.num_nodes
+        };
+
+        // We can now run the rest of the nodes
+        for i in existing_nodes_count..end {
+            let this_node = i + 1;
+
+            if self.add_nodes_to_existing_network {
+                debug!("Adding node #{}...", this_node)
+            } else {
+                debug!("Launching node #{}...", this_node)
+            };
+            node_cmd.run(
+                self.nodes_dir.join(format!("sn-node-{}", this_node)),
+                &genesis_contact_info,
+            )?;
+
+            // We wait for a few secs before launching each new node
+            thread::sleep(interval_duration);
+        }
+
+        info!("Done!");
+        Ok(())
     }
 }
 
@@ -131,32 +196,48 @@ pub struct Join {
 impl Join {
     /// Join a network with these arguments.
     pub fn run(&self) -> Result<()> {
-        join(self)
-    }
-
-    fn node_cmd(&self) -> Result<NodeCmd<'_>> {
-        let mut cmd = self.common.node_cmd()?;
+        let mut node_cmd = self.common.node_cmd()?;
+        node_cmd.print_version()?;
 
         if let Some(max_capacity) = self.max_capacity {
-            cmd.push_arg("--max-capacity");
-            cmd.push_arg(max_capacity.to_string());
+            node_cmd.push_arg("--max-capacity");
+            node_cmd.push_arg(max_capacity.to_string());
         }
 
         if let Some(local_addr) = self.local_addr {
-            cmd.push_arg("--local-addr");
-            cmd.push_arg(local_addr.to_string());
+            node_cmd.push_arg("--local-addr");
+            node_cmd.push_arg(local_addr.to_string());
         }
 
         if let Some(public_addr) = self.public_addr {
-            cmd.push_arg("--public-addr");
-            cmd.push_arg(public_addr.to_string());
+            node_cmd.push_arg("--public-addr");
+            node_cmd.push_arg(public_addr.to_string());
         }
 
         if self.clear_data {
-            cmd.push_arg("--clear-data");
+            node_cmd.push_arg("--clear-data");
         }
 
-        Ok(cmd)
+        if self.hard_coded_contacts.is_empty() {
+            debug!("Failed to start a node. No contacts nodes provided.");
+            return Ok(());
+        }
+
+        debug!(
+            "Node to be started with contact(s): {:?}",
+            self.hard_coded_contacts
+        );
+
+        debug!("Launching node...");
+        node_cmd.run(&self.nodes_dir, &self.hard_coded_contacts)?;
+
+        debug!(
+            "Node logs are being stored at: {}/sn_node.log<DATETIME>",
+            self.nodes_dir.display()
+        );
+        debug!("(Note that log files are rotated hourly, and subsequent files will be named sn_node.log<NEW DATE TINE>.");
+
+        Ok(())
     }
 }
 
@@ -177,7 +258,17 @@ struct CommonArgs {
 
 impl CommonArgs {
     fn node_cmd(&self) -> Result<NodeCmd> {
-        let mut cmd = NodeCmd::new(self.node_path()?);
+        let mut cmd = match self.node_path.as_deref() {
+            Some(p) => NodeCmd::new(p),
+            None => {
+                let mut path =
+                    dirs_next::home_dir().ok_or_else(|| eyre!("Home directory not found"))?;
+
+                path.push(".safe/node");
+                path.push(SN_NODE_EXECUTABLE);
+                NodeCmd::new(path)
+            }
+        };
 
         let rust_log = self.rust_log();
         info!("Using RUST_LOG '{}'", rust_log);
@@ -192,20 +283,6 @@ impl CommonArgs {
         Ok(cmd)
     }
 
-    fn node_path(&self) -> Result<Cow<'_, Path>> {
-        match self.node_path.as_deref() {
-            Some(p) => Ok(p.into()),
-            None => {
-                let mut path =
-                    dirs_next::home_dir().ok_or_else(|| eyre!("Home directory not found"))?;
-
-                path.push(".safe/node");
-                path.push(SN_NODE_EXECUTABLE);
-                Ok(path.into())
-            }
-        }
-    }
-
     fn rust_log(&self) -> Cow<'_, str> {
         match self.rust_log.as_deref() {
             Some(rust_log_flag) => rust_log_flag.into(),
@@ -215,107 +292,6 @@ impl CommonArgs {
             },
         }
     }
-}
-
-fn launch(args: &Launch) -> Result<()> {
-    let node_cmd = args.node_cmd()?;
-    node_cmd.print_version()?;
-
-    debug!("Network size: {} nodes", args.num_nodes);
-
-    let interval_duration = Duration::from_secs(args.interval);
-
-    if !args.add_nodes_to_existing_network {
-        // Set genesis node's command arguments
-        let mut genesis_cmd = node_cmd.clone();
-        genesis_cmd.push_arg("--first");
-        if let Some(ip) = &args.ip {
-            genesis_cmd.push_arg(format!("{}:0", ip));
-        } else {
-            genesis_cmd.push_arg("127.0.0.1:0");
-        }
-
-        // Let's launch genesis node now
-        debug!("Launching genesis node (#1)...");
-        genesis_cmd.run(args.nodes_dir.join("sn-node-genesis"), &[])?;
-
-        thread::sleep(interval_duration);
-    }
-
-    // Fetch node_conn_info from $HOME/.safe/node/node_connection_info.config.
-    let genesis_contact_info = read_genesis_conn_info()?;
-
-    debug!(
-        "Common node args for launching the network: {:?}",
-        node_cmd.args()
-    );
-
-    let paths =
-        fs::read_dir(&args.nodes_dir).wrap_err("Could not read existing testnet log dir")?;
-
-    let existing_nodes_count = paths
-        .collect::<Result<Vec<_>, io::Error>>()
-        .wrap_err("Error collecting testnet log dir")?
-        .len();
-
-    info!("{:?} existing nodes found", existing_nodes_count);
-
-    if existing_nodes_count == 0 {
-        return Err(eyre!("A genesis node could not be found."));
-    }
-
-    let end: usize = if args.add_nodes_to_existing_network {
-        existing_nodes_count + args.num_nodes
-    } else {
-        args.num_nodes
-    };
-
-    // We can now run the rest of the nodes
-    for i in existing_nodes_count..end {
-        let this_node = i + 1;
-
-        if args.add_nodes_to_existing_network {
-            debug!("Adding node #{}...", this_node)
-        } else {
-            debug!("Launching node #{}...", this_node)
-        };
-        node_cmd.run(
-            args.nodes_dir.join(format!("sn-node-{}", this_node)),
-            &genesis_contact_info,
-        )?;
-
-        // We wait for a few secs before launching each new node
-        thread::sleep(interval_duration);
-    }
-
-    info!("Done!");
-    Ok(())
-}
-
-fn join(args: &Join) -> Result<()> {
-    let node_cmd = args.node_cmd()?;
-    node_cmd.print_version()?;
-
-    if args.hard_coded_contacts.is_empty() {
-        debug!("Failed to start a node. No contacts nodes provided.");
-        return Ok(());
-    }
-
-    debug!(
-        "Node to be started with contact(s): {:?}",
-        args.hard_coded_contacts
-    );
-
-    debug!("Launching node...");
-    node_cmd.run(&args.nodes_dir, &args.hard_coded_contacts)?;
-
-    debug!(
-        "Node logs are being stored at: {}/sn_node.log<DATETIME>",
-        args.nodes_dir.display()
-    );
-    debug!("(Note that log files are rotated hourly, and subsequent files will be named sn_node.log<NEW DATE TINE>.");
-
-    Ok(())
 }
 
 fn read_genesis_conn_info() -> Result<Vec<SocketAddr>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,6 @@ impl Launch {
     /// Launch a network with these arguments.
     pub fn run(&self) -> Result<()> {
         let mut node_cmd = self.common.node_cmd()?;
-        node_cmd.print_version()?;
 
         node_cmd.push_arg("--idle-timeout-msec");
         node_cmd.push_arg(self.idle_timeout_msec.to_string());
@@ -210,7 +209,6 @@ impl Join {
     /// Join a network with these arguments.
     pub fn run(&self) -> Result<()> {
         let mut node_cmd = self.common.node_cmd()?;
-        node_cmd.print_version()?;
 
         if let Some(max_capacity) = self.max_capacity {
             node_cmd.push_arg("--max-capacity");
@@ -291,6 +289,12 @@ impl CommonArgs {
             // We need a minimum of INFO level for nodes verbosity,
             // since the genesis node logs the contact info at INFO level
             format!("-{}", "v".repeat(2 + self.nodes_verbosity as usize)),
+        );
+
+        debug!(
+            "Using sn_node @ {} from {}",
+            cmd.version()?,
+            cmd.path().display()
         );
 
         Ok(cmd)

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@
 // Software.
 
 use eyre::Result;
-use sn_launch_tool::run;
-pub use sn_launch_tool::run_with;
+use sn_launch_tool::Launch;
+use structopt::StructOpt;
 use tracing::debug;
 
 fn main() -> Result<()> {
@@ -18,5 +18,5 @@ fn main() -> Result<()> {
 
     debug!("Launching Safe nodes...");
 
-    run()
+    Launch::from_args().run()
 }


### PR DESCRIPTION
This is ultimately intended to work towards two outcomes:

- Making the logic easier to grok. This has been achieved by separating some of the mechanical command building from the logic, and splitting up the remaining logic.
- A more 'programmatic' API. This has been started by exposing the argument structs as the entrypoint, rather than the 'run' functions. Although the struct fields are currently private, and thus they can only be constructed via `StructOpt` arg parsing, they could be made public, or have other public constructors added which would be non-breaking changes on top of this.

---

- fa49b85 **refactor!: Change API to use argument structs as entrypoints**

  Rather than the API being 'stringly typed' (e.g. passing arguments as
  `&[&str]`) we now make the argument struct public (under new names,
  `Launch` and `Join`). This makes the API more idiomatic to use.
  
  Currently, `structopt` is required to construct the argument structs,
  but this could be relaxed in future.
  
  BREAKING CHANGE: The `run`, `run_with`, `join`, and `join_with`
  functions have been removed. Instead use `Launch::run` or `Join::run`.
  These structs can be constructed via the `StructOpt` constructors.

- 4e9853e **refactor: Deduplicate common arguments into a struct**

  This gives us a place to centralise some of the common argument
  handling.

- 1b05e9e **refactor: Move node path handling to `CommonArgs`**

  The node path can be determined entirely from the `CommonArgs` struct,
  so it makes sense to locate this there. Printing the version is now a
  separate method.

- a346703 **refactor: Move `rust_log` handling to `CommonArgs`**

  Since it's a field of the struct, this is a more logical home for it.

- 1572bdf **refactor: Add `NodeCmd` struct for interacting with `sn_node`**

  The `NodeCmd` struct is intended to encapsulate the running of the node
  command, and can be extended to cover argument handling in future.

- 429de29 **refactor: Add args to `NodeCmd`**

  This centralises the handling of node verbosity.

- c093fe9 **refactor: Move more arguments into `NodeCmd`**

  Most arguments are now pushed directly to `NodeCmd`. This allows more
  flexibility in the values, making things more ergonomic and a bit
  shorter.

- 5e81969 **refactor: Move more argument handling to `NodeCmd`**

  This adds `NodeCmd` constructors to `Launch` and `Join`, which can then
  inject the relevant arguments.

- 05ee482 **refactor: Add a separate `NodeArgs` struct**

  This gets us better debug output.

- f87b1d7 **refactor: More `NodeCmd` APIs**

  `NodeCmd` now has a constructor and a `push_env` method. This simplifies
  construction considerably.

- 5ab7061 **refactor: Move remaining argument handling into `NodeCmd`**

  `NodeCmd::run` now handles the `node_dir` and `contact` arguments. This
  signature is more flexible than before, so the call-sites are simpler.

- 613c16c **refactor: Deduplicate logging of `RUST_LOG`**

  Also removes a comment that seems to be out of date.

- 5e00790 **refactor: Remove unnecessary aliased variable**


- e7e1a41 **refactor: Move `NodeCmd` and `NodeArgs` into `cmd` module**

  This was a pretty clean move, and it helps highlight areas where
  responsibility may be poorly assigned (e.g. duplicate imports).

- c187566 **refactor: Move 'run' fn body into their respective structs**

  The associated `run` functions now contain the whole logic, rather than
  delegating to a module-level function.

- abd9d7a **refactor: Split `Launch::run` into a few functions**

  This makes it much easier to tell at a glance what the function does.

- 4d58cec **refactor: Move version printing out of `NodeCmd`**

  It makes sense for `NodeCmd` to get the version, but not really to print
  it since this is more related to business logic.

- 3af568f **fix: Use `Launch::is_local` to skip IGD**

  This field wasn't being used, but it can be used to skip IGD when
  launching a local-only network.
