### PR TITLE
Update for node address config

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Bump Version
-        uses: maidsafe/rust-version-bump-branch-creator@v2
+        uses: maidsafe/rust-version-bump-branch-creator@v3
         with:
           token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+          target_branch: master

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,14 @@ impl Launch {
             node_cmd.push_arg("--skip-igd");
         }
 
+        if let Some(ip) = &self.ip {
+            node_cmd.push_arg("--local-addr");
+            node_cmd.push_arg(format!("{}:0", ip));
+        } else if self.is_local {
+            node_cmd.push_arg("--local-addr");
+            node_cmd.push_arg("127.0.0.1:0");
+        }
+
         debug!("Network size: {} nodes", self.num_nodes);
 
         let interval = Duration::from_secs(self.interval);
@@ -128,11 +136,6 @@ impl Launch {
         // Set genesis node's command arguments
         let mut genesis_cmd = node_cmd.clone();
         genesis_cmd.push_arg("--first");
-        if let Some(ip) = &self.ip {
-            genesis_cmd.push_arg(format!("{}:0", ip));
-        } else {
-            genesis_cmd.push_arg("127.0.0.1:0");
-        }
 
         // Let's launch genesis node now
         debug!("Launching genesis node (#1)...");


### PR DESCRIPTION
⚠️ There's essentially a circular dependency between `safe_network` and this repository, such that one must be updated before the other can be. Since `safe_network` needs a version for `sn_launch_tool`, it makes sense to merge this first, then update https://github.com/maidsafe/safe_network/pull/391 for the new version.

---

- 83cbdbb **ci: Upgrade `maidsafe/rust-version-bump-branch-creator`**

  The new version bumps the version in `Cargo.lock` and preserves the
  format of dependencies in `Cargo.toml`. It also changes the default
  branch to `main`, so we need to override that with the `target_branch`
  input.

- 695f4b4 **chore!: Update for changes to `sn_node` CLI**

  The `sn_node` CLI is changing to make `--first` a flag, rather than
  taking a value for the local/public address. The `--ip` argument is now
  used to set the `--local-addr` for `sn_node` for all nodes, not just
  genesis.
  
  BREAKING CHANGE: For genesis nodes, `sn_node` will now be invoked with
  `--first` without a value, which is not compatible with older versions
  of `sn_node`.
