### PR TITLE
feat: add a flag to enable JSON logs on `sn_node`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,6 +290,10 @@ struct CommonArgs {
     /// RUST_LOG env var value to launch the nodes with.
     #[structopt(short = "l", long)]
     rust_log: Option<String>,
+
+    /// Output logs in json format for easier processing.
+    #[structopt(long)]
+    json_logs: bool,
 }
 
 impl CommonArgs {
@@ -315,6 +319,10 @@ impl CommonArgs {
             // since the genesis node logs the contact info at INFO level
             format!("-{}", "v".repeat(2 + self.nodes_verbosity as usize)),
         );
+
+        if self.json_logs {
+            cmd.push_arg("--json-logs");
+        }
 
         debug!(
             "Using sn_node @ {} from {}",


### PR DESCRIPTION
- a18ace6 **feat: add a flag to enable JSON logs on `sn_node`**

  `sn_node` already supports the `--json-logs` flag, but supporting it
  here will make it easier to enable JSON logs from `testnet` (and
  potentially the CLI, in future).
