### PR TITLE
feat: set the --network-contacts-file node argument to the genesis node's prefix_map path

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -143,6 +143,7 @@ impl<'a> NodeCmd<'a> {
                 .current_dir(node_name)
                 .args(additonal_flame_args.clone());
         }
+
         the_cmd
             .args(&self.args)
             .args(&extra_args)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 MaidSafe.net limited.
+// Copyright 2022 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
 // http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
@@ -114,13 +114,17 @@ impl Launch {
             debug!("Genesis wait over...");
         }
 
-        debug!(
-            "Common node args for launching the network: {:?}",
-            node_cmd.args()
-        );
-
         let node_ids = self.node_ids()?;
         if !node_ids.is_empty() {
+            let genesis_contacts_filepath =
+                self.nodes_dir.join("sn-node-genesis").join("prefix_map");
+            node_cmd.push_arg("--network-contacts-file");
+            node_cmd.push_arg(genesis_contacts_filepath);
+
+            debug!(
+                "Common node args for launching the network: {:?}",
+                node_cmd.args()
+            );
             info!("Launching nodes {:?}", node_ids);
 
             for i in node_ids {
@@ -241,6 +245,10 @@ impl Join {
         if self.clear_data {
             node_cmd.push_arg("--clear-data");
         }
+
+        let genesis_contacts_filepath = self.nodes_dir.join("sn-node-genesis").join("prefix_map");
+        node_cmd.push_arg("--network-contacts-file");
+        node_cmd.push_arg(genesis_contacts_filepath);
 
         debug!("Launching node...");
         node_cmd.run(


### PR DESCRIPTION
- The sn_node binary now requires a file path to be provided with --network-contacts-file argument where
to read the network contacts from, the tool sets this arg to the genesis node's prefix_map file path.
- Set the genesis node as the default contact for local clients to bootstrap to, by copying genesis node's prefix map file to ~/.safe/prefix_maps/default`.